### PR TITLE
Prevent onchange event firing from undesired operation

### DIFF
--- a/jquery.AddIncSearch.js
+++ b/jquery.AddIncSearch.js
@@ -471,6 +471,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
 
             $input.blur(function(e) {
                 if (!over_blocker && !over_chooser) {
+                    $chooser.xCurrentRow = null;
                     input_hide();
                     return true;
                 }


### PR DESCRIPTION
Prevent onchange event firing when click outside of dropdown.
